### PR TITLE
Add ANBIMA IDKA dataset pipeline

### DIFF
--- a/.github/workflows/daily_scraper.yml
+++ b/.github/workflows/daily_scraper.yml
@@ -28,5 +28,7 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           ANBIMA_IRTS_HF_REPO_ID: rodrigomtorresb/anbima-irts
           ANBIMA_IRTS_HF_FILENAME: latest.parquet
+          ANBIMA_IDKA_HF_REPO_ID: rodrigomtorresb/anbima-idka
+          ANBIMA_IDKA_HF_FILENAME: latest.parquet
         run: |
           python auto_scrape.py

--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ parameters as a public Parquet dataset.
 The dataset is accumulated in a single latest blob. Generated data is published
 to Hugging Face and is not committed back into this Git repository.
 
+## ANBIMA IDKA Dataset
+
+FinScraps also publishes ANBIMA IDKA historical index levels as a wide public
+Parquet dataset.
+
+- Dataset repo: https://huggingface.co/datasets/rodrigomtorresb/anbima-idka
+- File: `latest.parquet`
+- Schema: `date`, `IDKAPRE3M`, `IDKAPRE1A`, `IDKAPRE2A`, `IDKAPRE3A`,
+  `IDKAPRE5A`, `IDKAIPCA2A`, `IDKAIPCA3A`, `IDKAIPCA5A`, `IDKAIPCA10A`,
+  `IDKAIPCA15A`, `IDKAIPCA20A`, `IDKAIPCA30A`
+
+Each IDKA column contains ANBIMA's `Número Índice` value. Derived return
+columns from the source workbooks are intentionally omitted.
+
 ## Usage
 
 ```python
@@ -23,8 +37,16 @@ url = "https://huggingface.co/datasets/rodrigomtorresb/anbima-irts/resolve/main/
 df = pd.read_parquet(url)
 ```
 
+```python
+import pandas as pd
+
+url = "https://huggingface.co/datasets/rodrigomtorresb/anbima-idka/resolve/main/latest.parquet"
+df = pd.read_parquet(url)
+```
+
 ## Automation
 
-The scraper runs on GitHub Actions after Brazilian market close, fetches the
-previous Brazilian business day, appends any missing rows to the latest Parquet
-blob, validates the result, and uploads the replacement file to Hugging Face.
+The scraper runs on GitHub Actions after Brazilian market close. It fetches the
+previous Brazilian business day for IRTS, rebuilds the cumulative IDKA wide
+frame from ANBIMA's historical workbooks, validates the resulting datasets, and
+uploads replacement files to Hugging Face when data changed.

--- a/auto_scrape.py
+++ b/auto_scrape.py
@@ -1,4 +1,4 @@
-from src.managers.Managers import AnbimaIRTSManager
+from src.managers.Managers import AnbimaIDKAManager, AnbimaIRTSManager
 from src.utils import BRCal
 import logging
 import os
@@ -15,5 +15,12 @@ if br_business_day:
     )
     AIRTSM.scrape_and_update(br_business_day)
     logging.info("Anbima IRTS data successfully scraped and updated.")
+
+    AIDKAM = AnbimaIDKAManager(
+        hf_repo_id=os.getenv("ANBIMA_IDKA_HF_REPO_ID", "rodrigomtorresb/anbima-idka"),
+        hf_filename=os.getenv("ANBIMA_IDKA_HF_FILENAME", "latest.parquet"),
+    )
+    AIDKAM.scrape_and_update(br_business_day)
+    logging.info("Anbima IDKA data successfully scraped and updated.")
 else:
     logging.info("Not a BR business day. Skipping BR scraping routines.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 huggingface_hub
+openpyxl
 pandas
 pyarrow
 requests

--- a/src/anbima_idka_dataset.py
+++ b/src/anbima_idka_dataset.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+
+IDKA_CODES = [
+    "IDKAPRE3M",
+    "IDKAPRE1A",
+    "IDKAPRE2A",
+    "IDKAPRE3A",
+    "IDKAPRE5A",
+    "IDKAIPCA2A",
+    "IDKAIPCA3A",
+    "IDKAIPCA5A",
+    "IDKAIPCA10A",
+    "IDKAIPCA15A",
+    "IDKAIPCA20A",
+    "IDKAIPCA30A",
+]
+COLUMNS = ["date", *IDKA_CODES]
+NUMERIC_COLUMNS = IDKA_CODES
+DEFAULT_HF_REPO_ID = "rodrigomtorresb/anbima-idka"
+DEFAULT_HF_FILENAME = "latest.parquet"
+
+
+def normalize_dataset(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalize the public ANBIMA IDKA dataset without changing its schema."""
+    missing_columns = [column for column in COLUMNS if column not in df.columns]
+    if missing_columns:
+        raise ValueError(f"Missing required columns: {missing_columns}")
+
+    normalized = df.loc[:, COLUMNS].copy()
+    normalized["date"] = pd.to_datetime(normalized["date"], errors="raise").dt.normalize()
+
+    for column in NUMERIC_COLUMNS:
+        normalized[column] = pd.to_numeric(normalized[column], errors="raise")
+
+    return normalized
+
+
+def validate_dataset(df: pd.DataFrame) -> pd.DataFrame:
+    normalized = normalize_dataset(df)
+
+    null_counts = normalized.isna().sum()
+    null_counts = null_counts[null_counts > 0]
+    if not null_counts.empty:
+        raise ValueError(f"Null values found: {null_counts.to_dict()}")
+
+    duplicate_count = int(normalized.duplicated(["date"]).sum())
+    if duplicate_count:
+        raise ValueError(f"Duplicate date rows found: {duplicate_count}")
+
+    if not normalized["date"].is_monotonic_increasing:
+        raise ValueError("Dates must be sorted in ascending order.")
+
+    return normalized.loc[:, COLUMNS]
+
+
+def read_parquet(path: str | Path) -> pd.DataFrame:
+    return pd.read_parquet(path)
+
+
+def write_parquet(df: pd.DataFrame, path: str | Path) -> None:
+    validated = validate_dataset(df)
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    validated.to_parquet(output_path, index=False)

--- a/src/hf_dataset.py
+++ b/src/hf_dataset.py
@@ -4,8 +4,6 @@ import os
 from pathlib import Path
 
 import pandas as pd
-from huggingface_hub import HfApi, hf_hub_download
-from huggingface_hub.errors import EntryNotFoundError, RepositoryNotFoundError
 
 from src.anbima_irts_dataset import DEFAULT_HF_FILENAME, DEFAULT_HF_REPO_ID, write_parquet
 
@@ -15,6 +13,9 @@ def load_latest_dataset(
     filename: str = DEFAULT_HF_FILENAME,
     token: str | None = None,
 ) -> pd.DataFrame:
+    from huggingface_hub import hf_hub_download
+    from huggingface_hub.errors import EntryNotFoundError, RepositoryNotFoundError
+
     try:
         path = hf_hub_download(
             repo_id=repo_id,
@@ -34,9 +35,12 @@ def upload_latest_dataset(
     filename: str = DEFAULT_HF_FILENAME,
     token: str | None = None,
     workdir: str | Path = "dist",
+    writer=write_parquet,
 ) -> None:
+    from huggingface_hub import HfApi
+
     output_path = Path(workdir) / filename
-    write_parquet(df, output_path)
+    writer(df, output_path)
 
     api = HfApi(token=token or os.environ.get("HF_TOKEN"))
     api.create_repo(repo_id=repo_id, repo_type="dataset", exist_ok=True)

--- a/src/managers/Managers.py
+++ b/src/managers/Managers.py
@@ -1,5 +1,13 @@
 import logging
 
+import pandas as pd
+
+from src.anbima_idka_dataset import (
+    DEFAULT_HF_FILENAME as DEFAULT_IDKA_HF_FILENAME,
+    DEFAULT_HF_REPO_ID as DEFAULT_IDKA_HF_REPO_ID,
+    validate_dataset as validate_idka_dataset,
+    write_parquet as write_idka_parquet,
+)
 from src.anbima_irts_dataset import (
     DEFAULT_HF_FILENAME,
     DEFAULT_HF_REPO_ID,
@@ -7,7 +15,7 @@ from src.anbima_irts_dataset import (
     validate_dataset,
 )
 from src.hf_dataset import load_latest_dataset, upload_latest_dataset
-from src.scrapers.Scrapers import AnbimaIRTSScraper
+from src.scrapers.Scrapers import AnbimaIDKAScraper, AnbimaIRTSScraper
 from src.utils import BRCal
 
 logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(asctime)s - %(name)s - %(message)s")
@@ -106,6 +114,110 @@ class AnbimaIRTSManager:
             True if the date is valid for scraping; otherwise False.
         """
         
+        if not self.calendar.is_business_day(date):
+            self.logger.warning(
+                f"Provided date {date.date()} is not a business day. Skipping."
+            )
+            return False
+
+        if date > self.calendar.today:
+            self.logger.warning(
+                f"Provided date {date.date()} is in the future. Skipping."
+            )
+            return False
+
+        day_count = len(self.calendar.day_range(date, self.calendar.today))
+        if day_count > 5:
+            self.logger.warning(
+                f"Provided date {date.date()} is older than 5 business days. Skipping."
+            )
+            return False
+
+        return True
+
+
+class AnbimaIDKAManager:
+    """
+    A manager for the AnbimaIDKAScraper. Handles the workflow of:
+    - Validating the requested date
+    - Downloading the cumulative IDKA source workbooks
+    - Comparing the canonical wide frame with the latest Hugging Face dataset
+    - Uploading a replacement Parquet blob only when the dataset changed
+    """
+
+    def __init__(
+        self,
+        hf_repo_id: str = DEFAULT_IDKA_HF_REPO_ID,
+        hf_filename: str = DEFAULT_IDKA_HF_FILENAME,
+    ):
+        """
+        Parameters
+        ----------
+        hf_repo_id : str
+            Hugging Face Dataset repo that stores the latest Parquet blob.
+        hf_filename : str
+            Dataset filename inside the Hugging Face repo.
+        """
+        self.scraper = AnbimaIDKAScraper()
+        self.hf_repo_id = hf_repo_id
+        self.hf_filename = hf_filename
+        self.calendar = BRCal()
+
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def scrape_and_update(self, date):
+        """Download IDKA history, then update the Hugging Face latest blob if changed."""
+        if not self._validate_date(date):
+            return False
+
+        existing_df = load_latest_dataset(self.hf_repo_id, self.hf_filename)
+        if existing_df.empty:
+            self.logger.info("No existing Hugging Face dataset found. Creating a new one.")
+            existing = pd.DataFrame()
+        else:
+            existing = validate_idka_dataset(existing_df)
+            self.logger.info(f"Existing dataset loaded with {existing.shape[0]} rows.")
+
+        self.logger.info("Starting IDKA historical workbook scrape...")
+        try:
+            new_data = self.scraper.scrape()
+        except Exception as e:
+            self.logger.error(f"Error during scraping: {e}")
+            raise
+
+        if date not in set(new_data["date"]):
+            self.logger.warning(
+                f"Scraped IDKA data does not contain requested date {date.date()}."
+            )
+
+        self.logger.info(
+            f"IDKA data fetched: {new_data.shape[0]} rows from "
+            f"{new_data['date'].min().date()} to {new_data['date'].max().date()}."
+        )
+
+        if not existing.empty and existing.equals(new_data):
+            self.logger.info("IDKA dataset is unchanged. Skipping upload.")
+            return False
+
+        upload_latest_dataset(
+            new_data,
+            self.hf_repo_id,
+            self.hf_filename,
+            writer=write_idka_parquet,
+        )
+        self.logger.info(
+            f"Uploaded {self.hf_repo_id}/{self.hf_filename} with {new_data.shape[0]} rows."
+        )
+
+        return True
+
+    def _validate_date(self, date):
+        """
+        Validate the requested date to ensure:
+        - It's not in the future
+        - It's not older than 5 business days from today
+        """
+
         if not self.calendar.is_business_day(date):
             self.logger.warning(
                 f"Provided date {date.date()} is not a business day. Skipping."

--- a/src/scrapers/Scrapers.py
+++ b/src/scrapers/Scrapers.py
@@ -2,6 +2,10 @@ import time
 import pandas as pd
 import requests
 import xml.etree.ElementTree as ET
+from io import BytesIO
+from functools import reduce
+
+from src.anbima_idka_dataset import IDKA_CODES, validate_dataset
 
 class AnbimaIRTSScraper:
     """A scraper for retrieving and parsing IRTS (Term Structure) data from ANBIMA in XML format.
@@ -101,3 +105,62 @@ class AnbimaIRTSScraper:
         xml_content = self.download_xml(date)
         parametros = self.parse_params(xml_content, date)
         return pd.DataFrame(parametros)
+
+
+class AnbimaIDKAScraper:
+    """A scraper for retrieving and parsing ANBIMA IDKA historical workbooks."""
+
+    BASE_URL = "https://s3-data-prd-use1-precos.s3.us-east-1.amazonaws.com/arquivos/indices-historico"
+    SOURCE_COLUMNS = ["Data de Referência", "Número Índice"]
+
+    def __init__(self):
+        self.urls = {
+            code: f"{self.BASE_URL}/{code}-HISTORICO.xls"
+            for code in IDKA_CODES
+        }
+
+    def download_workbook(self, code: str) -> bytes:
+        """Download one IDKA historical workbook, with simple retry logic."""
+        max_retries = 5
+        for attempt in range(max_retries):
+            try:
+                response = requests.get(self.urls[code], timeout=30)
+                response.raise_for_status()
+                return response.content
+            except requests.exceptions.RequestException as e:
+                if attempt < max_retries - 1:
+                    time.sleep(1)
+                else:
+                    raise e
+
+    def parse_workbook(self, workbook_content: bytes, code: str) -> pd.DataFrame:
+        """Parse an IDKA workbook into a two-column date/value frame."""
+        df = pd.read_excel(
+            BytesIO(workbook_content),
+            sheet_name="Historico",
+            engine="openpyxl",
+            usecols=self.SOURCE_COLUMNS,
+        )
+        parsed = df.rename(
+            columns={
+                "Data de Referência": "date",
+                "Número Índice": code,
+            }
+        )
+        parsed["date"] = pd.to_datetime(parsed["date"], errors="raise").dt.normalize()
+        parsed[code] = pd.to_numeric(parsed[code], errors="raise")
+        return parsed.loc[:, ["date", code]]
+
+    def scrape(self) -> pd.DataFrame:
+        """Download all IDKA workbooks and return the public wide dataset."""
+        series_frames = [
+            self.parse_workbook(self.download_workbook(code), code)
+            for code in IDKA_CODES
+        ]
+
+        wide_df = reduce(
+            lambda left, right: left.merge(right, on="date", how="outer", validate="one_to_one"),
+            series_frames,
+        )
+        wide_df = wide_df.sort_values("date").reset_index(drop=True)
+        return validate_dataset(wide_df)

--- a/tests/test_anbima_idka_dataset.py
+++ b/tests/test_anbima_idka_dataset.py
@@ -1,0 +1,159 @@
+from io import BytesIO
+import logging
+import unittest
+from unittest.mock import patch
+
+import pandas as pd
+
+from src.anbima_idka_dataset import COLUMNS, IDKA_CODES, validate_dataset
+from src.managers.Managers import AnbimaIDKAManager
+from src.scrapers.Scrapers import AnbimaIDKAScraper
+
+
+class AnbimaIDKADatasetTests(unittest.TestCase):
+    def _valid_df(self):
+        rows = []
+        for date, offset in [("2025-01-02", 0), ("2025-01-03", 100)]:
+            row = {"date": date}
+            for position, code in enumerate(IDKA_CODES):
+                row[code] = 1000.0 + offset + position
+            rows.append(row)
+        return pd.DataFrame(rows, columns=COLUMNS)
+
+    def test_validate_dataset_accepts_public_schema(self):
+        validated = validate_dataset(self._valid_df())
+
+        self.assertEqual(list(validated.columns), COLUMNS)
+        self.assertEqual(validated["date"].tolist(), [pd.Timestamp("2025-01-02"), pd.Timestamp("2025-01-03")])
+
+    def test_validate_dataset_rejects_missing_required_columns(self):
+        df = self._valid_df().drop(columns=["IDKAPRE3M"])
+
+        with self.assertRaises(ValueError):
+            validate_dataset(df)
+
+    def test_validate_dataset_rejects_duplicate_dates(self):
+        df = pd.concat([self._valid_df(), self._valid_df().iloc[[0]]], ignore_index=True)
+
+        with self.assertRaises(ValueError):
+            validate_dataset(df)
+
+    def test_validate_dataset_rejects_null_values(self):
+        df = self._valid_df()
+        df.loc[0, "IDKAIPCA10A"] = None
+
+        with self.assertRaises(ValueError):
+            validate_dataset(df)
+
+    def test_validate_dataset_rejects_non_numeric_values(self):
+        df = self._valid_df()
+        df["IDKAPRE1A"] = df["IDKAPRE1A"].astype(object)
+        df.loc[0, "IDKAPRE1A"] = "not-a-number"
+
+        with self.assertRaises(ValueError):
+            validate_dataset(df)
+
+    def test_validate_dataset_rejects_unsorted_dates(self):
+        df = self._valid_df().iloc[::-1].reset_index(drop=True)
+
+        with self.assertRaises(ValueError):
+            validate_dataset(df)
+
+
+class AnbimaIDKAScraperTests(unittest.TestCase):
+    def _workbook(self, values):
+        output = BytesIO()
+        df = pd.DataFrame(
+            {
+                "Índice": ["IDkA Test"] * len(values),
+                "Data de Referência": [date for date, _ in values],
+                "Número Índice": [value for _, value in values],
+                "Variação Diária (%)": [0.1] * len(values),
+            }
+        )
+        with pd.ExcelWriter(output, engine="openpyxl") as writer:
+            df.to_excel(writer, sheet_name="Historico", index=False)
+        return output.getvalue()
+
+    def test_parse_workbook_extracts_date_and_index_value(self):
+        scraper = AnbimaIDKAScraper()
+
+        parsed = scraper.parse_workbook(
+            self._workbook([("2025-01-02", 1000.0), ("2025-01-03", 1001.5)]),
+            "IDKAPRE3M",
+        )
+
+        expected = pd.DataFrame(
+            {
+                "date": [pd.Timestamp("2025-01-02"), pd.Timestamp("2025-01-03")],
+                "IDKAPRE3M": [1000.0, 1001.5],
+            }
+        )
+        pd.testing.assert_frame_equal(parsed, expected)
+
+    def test_scrape_builds_wide_frame_in_public_column_order(self):
+        scraper = AnbimaIDKAScraper()
+        workbooks = {
+            code: self._workbook([("2025-01-02", 1000.0 + idx), ("2025-01-03", 1100.0 + idx)])
+            for idx, code in enumerate(IDKA_CODES)
+        }
+        scraper.download_workbook = lambda code: workbooks[code]
+
+        result = scraper.scrape()
+
+        self.assertEqual(list(result.columns), COLUMNS)
+        self.assertEqual(result.shape, (2, len(COLUMNS)))
+        self.assertEqual(result.loc[0, "IDKAPRE3M"], 1000.0)
+        self.assertEqual(result.loc[1, "IDKAIPCA30A"], 1100.0 + len(IDKA_CODES) - 1)
+
+
+class AnbimaIDKAManagerTests(unittest.TestCase):
+    def _manager(self, scraped_df):
+        manager = AnbimaIDKAManager.__new__(AnbimaIDKAManager)
+        manager.scraper = type("DummyScraper", (), {"scrape": lambda self: scraped_df})()
+        manager.hf_repo_id = "test/idka"
+        manager.hf_filename = "latest.parquet"
+        manager.logger = logging.getLogger("AnbimaIDKAManagerTests")
+        manager._validate_date = lambda date: True
+        return manager
+
+    def _valid_df(self, extra_day=False):
+        rows = []
+        dates = ["2025-01-02", "2025-01-03"]
+        if extra_day:
+            dates.append("2025-01-06")
+        for offset, date in enumerate(dates):
+            row = {"date": pd.Timestamp(date)}
+            for position, code in enumerate(IDKA_CODES):
+                row[code] = 1000.0 + (offset * 100) + position
+            rows.append(row)
+        return pd.DataFrame(rows, columns=COLUMNS)
+
+    @patch("src.managers.Managers.upload_latest_dataset")
+    @patch("src.managers.Managers.load_latest_dataset")
+    def test_manager_skips_upload_when_dataset_is_unchanged(self, load_latest, upload_latest):
+        df = self._valid_df()
+        load_latest.return_value = df.copy()
+        manager = self._manager(df.copy())
+
+        changed = manager.scrape_and_update(pd.Timestamp("2025-01-03"))
+
+        self.assertFalse(changed)
+        upload_latest.assert_not_called()
+
+    @patch("src.managers.Managers.upload_latest_dataset")
+    @patch("src.managers.Managers.load_latest_dataset")
+    def test_manager_uploads_when_dataset_changed(self, load_latest, upload_latest):
+        existing = self._valid_df()
+        scraped = self._valid_df(extra_day=True)
+        load_latest.return_value = existing
+        manager = self._manager(scraped)
+
+        changed = manager.scrape_and_update(pd.Timestamp("2025-01-06"))
+
+        self.assertTrue(changed)
+        upload_latest.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add IDKA wide-frame dataset validation and Parquet writer
- add IDKA scraper/manager and wire it into the daily scraper workflow
- document the new Hugging Face dataset and add focused parser/manager tests

## Verification
- python -m unittest discover -s tests