### PR TITLE
Harden Hugging Face scraper updates

### DIFF
--- a/scripts/migrate_anbima_irts_to_hf.py
+++ b/scripts/migrate_anbima_irts_to_hf.py
@@ -74,7 +74,7 @@ def main() -> None:
         try:
             from src.hf_dataset import upload_latest_dataset
 
-            upload_latest_dataset(validated_df, repo_id=args.repo_id, filename=args.filename)
+            upload_latest_dataset(validated_df, repo_id=args.repo_id, filename=args.filename, create_repo=True)
         except ImportError:
             subprocess.run(
                 [

--- a/src/hf_dataset.py
+++ b/src/hf_dataset.py
@@ -1,11 +1,121 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+import logging
 import os
 from pathlib import Path
+import random
+import time
+from typing import Callable, TypeVar
 
 import pandas as pd
 
 from src.anbima_irts_dataset import DEFAULT_HF_FILENAME, DEFAULT_HF_REPO_ID, write_parquet
+
+
+LOGGER = logging.getLogger(__name__)
+RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+DEFAULT_MAX_RETRIES = 3
+DEFAULT_MAX_RETRY_SECONDS = 120
+DEFAULT_MAX_SLEEP_SECONDS = 30
+DEFAULT_INITIAL_DELAY_SECONDS = 2
+T = TypeVar("T")
+
+
+def _call_with_retries(
+    operation: Callable[[], T],
+    description: str,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    max_retry_seconds: float = DEFAULT_MAX_RETRY_SECONDS,
+    max_sleep_seconds: float = DEFAULT_MAX_SLEEP_SECONDS,
+    initial_delay_seconds: float = DEFAULT_INITIAL_DELAY_SECONDS,
+) -> T:
+    start = time.monotonic()
+    attempt = 0
+
+    while True:
+        try:
+            return operation()
+        except Exception as error:
+            if not _is_retryable_hf_error(error) or attempt >= max_retries:
+                raise
+
+            delay = _retry_delay_seconds(
+                error,
+                attempt,
+                max_sleep_seconds=max_sleep_seconds,
+                initial_delay_seconds=initial_delay_seconds,
+            )
+            elapsed = time.monotonic() - start
+            if delay > max_sleep_seconds or elapsed + delay > max_retry_seconds:
+                LOGGER.warning(
+                    "Not retrying %s after transient Hugging Face error; "
+                    "delay %.1fs exceeds retry budget.",
+                    description,
+                    delay,
+                )
+                raise
+
+            LOGGER.warning(
+                "Retrying %s in %.1fs after transient Hugging Face error.",
+                description,
+                delay,
+            )
+            time.sleep(delay)
+            attempt += 1
+
+
+def _is_retryable_hf_error(error: Exception) -> bool:
+    status_code = _status_code(error)
+    if status_code is not None:
+        return status_code in RETRYABLE_STATUS_CODES
+
+    module = error.__class__.__module__.split(".", 1)[0]
+    return module in {"httpx", "requests"}
+
+
+def _retry_delay_seconds(
+    error: Exception,
+    attempt: int,
+    max_sleep_seconds: float,
+    initial_delay_seconds: float,
+) -> float:
+    retry_after = _retry_after_seconds(error)
+    if retry_after is not None:
+        return retry_after
+
+    delay = initial_delay_seconds * (2 ** attempt)
+    jitter = random.uniform(0, min(1.0, delay * 0.1))
+    return min(max_sleep_seconds, delay + jitter)
+
+
+def _retry_after_seconds(error: Exception) -> float | None:
+    response = getattr(error, "response", None)
+    headers = getattr(response, "headers", None)
+    if not headers:
+        return None
+
+    value = headers.get("Retry-After")
+    if value is None:
+        return None
+
+    try:
+        return max(0.0, float(value))
+    except ValueError:
+        try:
+            retry_at = parsedate_to_datetime(value)
+        except (TypeError, ValueError):
+            return None
+
+    if retry_at.tzinfo is None:
+        retry_at = retry_at.replace(tzinfo=timezone.utc)
+    return max(0.0, (retry_at - datetime.now(timezone.utc)).total_seconds())
+
+
+def _status_code(error: Exception) -> int | None:
+    response = getattr(error, "response", None)
+    return getattr(response, "status_code", None)
 
 
 def load_latest_dataset(
@@ -14,16 +124,29 @@ def load_latest_dataset(
     token: str | None = None,
 ) -> pd.DataFrame:
     from huggingface_hub import hf_hub_download
-    from huggingface_hub.errors import EntryNotFoundError, RepositoryNotFoundError
+    from huggingface_hub.errors import (
+        EntryNotFoundError,
+        LocalEntryNotFoundError,
+        RepositoryNotFoundError,
+    )
 
     try:
-        path = hf_hub_download(
-            repo_id=repo_id,
-            filename=filename,
-            repo_type="dataset",
-            token=token or os.environ.get("HF_TOKEN"),
+        path = _call_with_retries(
+            lambda: hf_hub_download(
+                repo_id=repo_id,
+                filename=filename,
+                repo_type="dataset",
+                token=token or os.environ.get("HF_TOKEN"),
+            ),
+            f"download {repo_id}/{filename}",
         )
-    except (EntryNotFoundError, RepositoryNotFoundError):
+    except LocalEntryNotFoundError:
+        raise
+    except RepositoryNotFoundError as error:
+        if _status_code(error) not in (None, 404):
+            raise
+        return pd.DataFrame()
+    except EntryNotFoundError:
         return pd.DataFrame()
 
     return pd.read_parquet(path)
@@ -36,6 +159,7 @@ def upload_latest_dataset(
     token: str | None = None,
     workdir: str | Path = "dist",
     writer=write_parquet,
+    create_repo: bool = False,
 ) -> None:
     from huggingface_hub import HfApi
 
@@ -43,11 +167,18 @@ def upload_latest_dataset(
     writer(df, output_path)
 
     api = HfApi(token=token or os.environ.get("HF_TOKEN"))
-    api.create_repo(repo_id=repo_id, repo_type="dataset", exist_ok=True)
-    api.upload_file(
-        path_or_fileobj=str(output_path),
-        path_in_repo=filename,
-        repo_id=repo_id,
-        repo_type="dataset",
-        commit_message=f"Update {filename}",
+    if create_repo:
+        _call_with_retries(
+            lambda: api.create_repo(repo_id=repo_id, repo_type="dataset", exist_ok=True),
+            f"create Hugging Face dataset repo {repo_id}",
+        )
+    _call_with_retries(
+        lambda: api.upload_file(
+            path_or_fileobj=str(output_path),
+            path_in_repo=filename,
+            repo_id=repo_id,
+            repo_type="dataset",
+            commit_message=f"Update {filename}",
+        ),
+        f"upload {repo_id}/{filename}",
     )

--- a/src/managers/Managers.py
+++ b/src/managers/Managers.py
@@ -20,6 +20,9 @@ from src.utils import BRCal
 
 logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(asctime)s - %(name)s - %(message)s")
 
+DEFAULT_IRTS_LOOKBACK_BUSINESS_DAYS = 5
+
+
 class AnbimaIRTSManager:
     """
     A manager for the AnbimaIRTSScraper. Handles the workflow of:
@@ -49,46 +52,51 @@ class AnbimaIRTSManager:
 
         self.logger = logging.getLogger(self.__class__.__name__)
 
-    def scrape_and_update(self, date):
-        """Download and parse IRTS data, then update the Hugging Face latest blob.
-
-        Parameters
-        ----------
-        date : datetime or datetime-like
-        Returns
-        -------
-        pd.DataFrame or None
-            DataFrame containing the merged dataset (old + new) if scraping is done;
-            None if skipped due to invalid date or data already present.
-        """
+    def scrape_and_update(self, date, lookback_business_days=DEFAULT_IRTS_LOOKBACK_BUSINESS_DAYS):
+        """Download and parse missing recent IRTS data, then update Hugging Face."""
+        date = pd.Timestamp(date).normalize()
         if not self._validate_date(date):
             return False
 
         existing_df = load_latest_dataset(self.hf_repo_id, self.hf_filename)
         if existing_df.empty:
             self.logger.info("No existing Hugging Face dataset found. Creating a new one.")
+            dates_to_scrape = [date]
         else:
             existing_df = validate_dataset(existing_df)
-            if date in existing_df["date"].unique():
-                self.logger.info(f"Data for date {date.date()} is already present. Skipping scrape.")
-                return False
             self.logger.info(f"Existing dataset loaded with {existing_df.shape[0]} rows.")
+            existing_dates = set(existing_df["date"].unique())
+            dates_to_scrape = [
+                candidate
+                for candidate in self._recent_business_dates(date, lookback_business_days)
+                if candidate not in existing_dates
+            ]
 
-        self.logger.info(f"Starting data scrape for date: {date}...")
-        try:
-            new_data = self.scraper.scrape(date)
-            new_nrows = new_data.shape[0]
-        except Exception as e:
-            self.logger.error(f"Error during scraping: {e}")
-            raise
+        if not dates_to_scrape:
+            self.logger.info(
+                f"No missing IRTS dates found through {date.date()}. Skipping scrape."
+            )
+            return False
 
-        self.logger.info(
-            f"New data fetched for date {date.date()}: {new_nrows} rows"
-        )
+        new_frames = []
+        for scrape_date in dates_to_scrape:
+            self.logger.info(f"Starting data scrape for date: {scrape_date}...")
+            try:
+                new_data = self.scraper.scrape(scrape_date)
+                new_nrows = new_data.shape[0]
+            except Exception as e:
+                self.logger.error(f"Error during scraping: {e}")
+                raise
 
+            self.logger.info(
+                f"New data fetched for date {scrape_date.date()}: {new_nrows} rows"
+            )
+            new_frames.append(new_data)
+
+        new_data = pd.concat(new_frames, ignore_index=True)
         combined_df, added_rows = merge_new_rows(existing_df, new_data)
         if added_rows == 0:
-            self.logger.info(f"No new rows for date {date.date()}. Skipping upload.")
+            self.logger.info("No new IRTS rows found. Skipping upload.")
             return False
 
         upload_latest_dataset(combined_df, self.hf_repo_id, self.hf_filename)
@@ -97,6 +105,15 @@ class AnbimaIRTSManager:
         )
 
         return True
+
+    def _recent_business_dates(self, date, lookback_business_days):
+        date = pd.Timestamp(date).normalize()
+        dates = [date]
+        current = date
+        while len(dates) < lookback_business_days:
+            current = self.calendar.previous_business_day(current)
+            dates.append(pd.Timestamp(current).normalize())
+        return list(reversed(dates))
 
     def _validate_date(self, date):
         """

--- a/tests/test_anbima_irts_dataset.py
+++ b/tests/test_anbima_irts_dataset.py
@@ -1,5 +1,7 @@
 import unittest
+from unittest.mock import patch
 
+import logging
 import pandas as pd
 
 from src.anbima_irts_dataset import (
@@ -8,6 +10,7 @@ from src.anbima_irts_dataset import (
     merge_new_rows,
     validate_dataset,
 )
+from src.managers.Managers import AnbimaIRTSManager
 
 
 class AnbimaIRTSDatasetTests(unittest.TestCase):
@@ -62,6 +65,54 @@ class AnbimaIRTSDatasetTests(unittest.TestCase):
         self.assertEqual(added_rows, 2)
         self.assertEqual(len(merged), 4)
         validate_dataset(merged)
+
+
+class AnbimaIRTSManagerTests(unittest.TestCase):
+    def _rows(self, date, offset=0.0):
+        return pd.DataFrame(
+            [
+                [date, "ipca", 0.5 + offset, 0.6, 0.7, 0.8, 3.0, 4.0],
+                [date, "pre", 0.1 + offset, 0.2, 0.3, 0.4, 1.0, 2.0],
+            ],
+            columns=COLUMNS,
+        )
+
+    def _manager(self, scraped_by_date, recent_dates):
+        manager = AnbimaIRTSManager.__new__(AnbimaIRTSManager)
+        manager.scraper = type(
+            "DummyScraper",
+            (),
+            {"scrape": lambda self, date: scraped_by_date[pd.Timestamp(date)]},
+        )()
+        manager.hf_repo_id = "test/irts"
+        manager.hf_filename = "latest.parquet"
+        manager.logger = logging.getLogger("AnbimaIRTSManagerTests")
+        manager._validate_date = lambda date: True
+        manager._recent_business_dates = lambda date, lookback_business_days: recent_dates
+        return manager
+
+    @patch("src.managers.Managers.upload_latest_dataset")
+    @patch("src.managers.Managers.load_latest_dataset")
+    def test_manager_backfills_missing_recent_date_when_target_is_present(self, load_latest, upload_latest):
+        target = pd.Timestamp("2025-01-06")
+        missing = pd.Timestamp("2025-01-03")
+        existing = pd.concat(
+            [self._rows("2025-01-02"), self._rows(target, offset=0.1)],
+            ignore_index=True,
+        )
+        load_latest.return_value = existing
+        manager = self._manager(
+            {missing: self._rows(missing, offset=0.2)},
+            [pd.Timestamp("2025-01-02"), missing, target],
+        )
+
+        changed = manager.scrape_and_update(target)
+
+        self.assertTrue(changed)
+        upload_latest.assert_called_once()
+        uploaded_df = upload_latest.call_args.args[0]
+        self.assertEqual(len(uploaded_df), 6)
+        self.assertEqual(int((uploaded_df["date"] == missing).sum()), 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_hf_dataset.py
+++ b/tests/test_hf_dataset.py
@@ -1,0 +1,123 @@
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+import httpx
+import pandas as pd
+from huggingface_hub.errors import EntryNotFoundError, HfHubHTTPError, LocalEntryNotFoundError
+
+from src.hf_dataset import _call_with_retries, load_latest_dataset, upload_latest_dataset
+
+
+def _hf_error(status_code, retry_after=None):
+    headers = {}
+    if retry_after is not None:
+        headers["Retry-After"] = str(retry_after)
+    request = httpx.Request("GET", "https://huggingface.co/datasets/test/repo/resolve/main/latest.parquet")
+    response = httpx.Response(status_code, headers=headers, request=request)
+    return HfHubHTTPError(f"HTTP {status_code}", response=response)
+
+
+class HuggingFaceDatasetTests(unittest.TestCase):
+    @patch("huggingface_hub.hf_hub_download")
+    def test_load_latest_dataset_returns_empty_for_missing_file(self, hf_hub_download):
+        hf_hub_download.side_effect = EntryNotFoundError("missing file")
+
+        result = load_latest_dataset("test/repo", "latest.parquet")
+
+        self.assertTrue(result.empty)
+
+    @patch("huggingface_hub.hf_hub_download")
+    def test_load_latest_dataset_raises_local_cache_miss(self, hf_hub_download):
+        hf_hub_download.side_effect = LocalEntryNotFoundError("rate limited before download")
+
+        with self.assertRaises(LocalEntryNotFoundError):
+            load_latest_dataset("test/repo", "latest.parquet")
+
+    @patch("src.hf_dataset.time.sleep")
+    def test_retry_after_above_cap_fails_fast(self, sleep):
+        operation = Mock(side_effect=_hf_error(429, retry_after=600))
+
+        with self.assertRaises(HfHubHTTPError):
+            _call_with_retries(
+                operation,
+                "download test dataset",
+                max_retries=5,
+                max_retry_seconds=120,
+                max_sleep_seconds=30,
+            )
+
+        self.assertEqual(operation.call_count, 1)
+        sleep.assert_not_called()
+
+    @patch("src.hf_dataset.time.sleep")
+    def test_retry_uses_short_retry_after_then_succeeds(self, sleep):
+        operation = Mock(side_effect=[_hf_error(429, retry_after=2), "ok"])
+
+        result = _call_with_retries(
+            operation,
+            "download test dataset",
+            max_retries=5,
+            max_retry_seconds=120,
+            max_sleep_seconds=30,
+        )
+
+        self.assertEqual(result, "ok")
+        self.assertEqual(operation.call_count, 2)
+        sleep.assert_called_once_with(2.0)
+
+    @patch("src.hf_dataset.time.sleep")
+    def test_retry_handles_transient_network_error(self, sleep):
+        request = httpx.Request("GET", "https://huggingface.co/datasets/test/repo")
+        operation = Mock(side_effect=[httpx.ConnectError("offline", request=request), "ok"])
+
+        result = _call_with_retries(
+            operation,
+            "download test dataset",
+            max_retries=5,
+            max_retry_seconds=120,
+            max_sleep_seconds=30,
+        )
+
+        self.assertEqual(result, "ok")
+        self.assertEqual(operation.call_count, 2)
+        sleep.assert_called_once()
+
+    @patch("huggingface_hub.HfApi")
+    def test_upload_skips_repo_creation_by_default(self, hf_api):
+        api = hf_api.return_value
+        writer = Mock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            upload_latest_dataset(
+                pd.DataFrame({"date": [pd.Timestamp("2025-01-02")]}),
+                "test/repo",
+                "latest.parquet",
+                workdir=tmpdir,
+                writer=writer,
+            )
+
+        api.create_repo.assert_not_called()
+        api.upload_file.assert_called_once()
+
+    @patch("src.hf_dataset.time.sleep")
+    @patch("huggingface_hub.HfApi")
+    def test_upload_file_retries_transient_rate_limit(self, hf_api, sleep):
+        api = hf_api.return_value
+        api.upload_file.side_effect = [_hf_error(429, retry_after=1), None]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            upload_latest_dataset(
+                pd.DataFrame({"date": [pd.Timestamp("2025-01-02")]}),
+                "test/repo",
+                "latest.parquet",
+                workdir=tmpdir,
+                writer=Mock(),
+            )
+
+        self.assertEqual(api.upload_file.call_count, 2)
+        sleep.assert_called_once_with(1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add bounded retries for Hugging Face download/upload calls, including 429 Retry-After handling
- fail safely on local cache misses instead of treating rate limits as empty datasets
- skip repo creation by default during scheduled uploads and backfill missing recent IRTS dates automatically

## Tests
- python -m pytest -q